### PR TITLE
not every RIGHT_BRACE has a corresponding LEFT_BRACE, sometimes they …

### DIFF
--- a/lib/Perl/Lint/Policy/Variables/ProhibitReusedNames.pm
+++ b/lib/Perl/Lint/Policy/Variables/ProhibitReusedNames.pm
@@ -37,8 +37,11 @@ sub evaluate {
     my @local_vars_by_depth = ([]);
     for (my $i = 0, my $token_type; my $token = $tokens->[$i]; $i++) {
         $token_type = $token->{type};
-
-        if ($token_type == LEFT_BRACE) {
+        if ($token_type == LEFT_BRACE
+            or $token_type == HASH_DEREFERENCE
+            or $token_type == ARRAY_DEREFERENCE
+            or $token_type == SCALAR_DEREFERENCE
+            ) {
             $depth++;
             push @local_vars_by_depth, [];
             next;

--- a/t/Policy/Variables/prohibit_reused_names.t
+++ b/t/Policy/Variables/prohibit_reused_names.t
@@ -20,6 +20,17 @@ done_testing;
 __DATA__
 
 ===
+--- dscr: Dereference
+--- failures: 0
+--- params:
+--- input
+%{$x};
+@{$x};
+${$x};
+
+package Z;
+
+===
 --- dscr: Simple block
 --- failures: 2
 --- params:


### PR DESCRIPTION
…are paired with a HASH_DEREFERENCE/ARRAY_DEREFERENCE/SCALAR_DEREFERENCE, which results in a negative $depth

In this particular case, any code with two modules in one file where the first module does any kind of dereference using the long syntax will cause Perl::Lint to crash with an uncreatable array element error.  This is unfortunately only one instance of a general class of problems in the Perl::Lint system, where it appears that most if not all modules expect that every RIGHT_BRACE comes with a corresponding LEFT_BRACE.