### PR TITLE
Test fixes for B::Keywords 1.15

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,7 @@
       },
       "runtime" : {
          "requires" : {
-            "B::Keywords" : "0",
+            "B::Keywords" : "1.15",
             "Carp" : "0",
             "Compiler::Lexer" : "0.22",
             "Email::Address" : "0",

--- a/t/Policy/Variables/require_localized_punctuation_vars.t
+++ b/t/Policy/Variables/require_localized_punctuation_vars.t
@@ -70,8 +70,6 @@ local $' = ();
 local $POSTMATCH = ();
 local $+ = ();
 local $LAST_PAREN_MATCH = ();
-local $* = ();
-local $MULTILINE_MATCHING = ();
 local $. = ();
 local $INPUT_LINE_NUMBER = ();
 local $NR = ();
@@ -79,7 +77,7 @@ local $/ = ();
 local $INPUT_RECORD_SEPARATOR = ();
 local $RS = ();
 local $| = ();
-local $OUTPUT_AUTO_FLUSH = ();
+local $OUTPUT_AUTOFLUSH = ();
 local $, = ();
 local $OUTPUT_FIELD_SEPARATOR = ();
 local $OFS = ();
@@ -230,8 +228,6 @@ local ($') = ();
 local ($POSTMATCH) = ();
 local ($+) = ();
 local ($LAST_PAREN_MATCH) = ();
-local ($*) = ();
-local ($MULTILINE_MATCHING) = ();
 local ($.) = ();
 local ($INPUT_LINE_NUMBER) = ();
 local ($NR) = ();
@@ -239,7 +235,7 @@ local ($/) = ();
 local ($INPUT_RECORD_SEPARATOR) = ();
 local ($RS) = ();
 local ($|) = ();
-local ($OUTPUT_AUTO_FLUSH) = ();
+local ($OUTPUT_AUTOFLUSH) = ();
 local ($,) = ();
 local ($OUTPUT_FIELD_SEPARATOR) = ();
 local ($OFS) = ();
@@ -390,8 +386,6 @@ local (*STDERR) = ();
 (local $POSTMATCH) = ();
 (local $+) = ();
 (local $LAST_PAREN_MATCH) = ();
-(local $*) = ();
-(local $MULTILINE_MATCHING) = ();
 (local $.) = ();
 (local $INPUT_LINE_NUMBER) = ();
 (local $NR) = ();
@@ -399,7 +393,7 @@ local (*STDERR) = ();
 (local $INPUT_RECORD_SEPARATOR) = ();
 (local $RS) = ();
 (local $|) = ();
-(local $OUTPUT_AUTO_FLUSH) = ();
+(local $OUTPUT_AUTOFLUSH) = ();
 (local $,) = ();
 (local $OUTPUT_FIELD_SEPARATOR) = ();
 (local $OFS) = ();
@@ -550,8 +544,6 @@ local (*STDERR) = ();
 @foo = (local $POSTMATCH) = ();
 @foo = (local $+) = ();
 @foo = (local $LAST_PAREN_MATCH) = ();
-@foo = (local $*) = ();
-@foo = (local $MULTILINE_MATCHING) = ();
 @foo = (local $.) = ();
 @foo = (local $INPUT_LINE_NUMBER) = ();
 @foo = (local $NR) = ();
@@ -559,7 +551,7 @@ local (*STDERR) = ();
 @foo = (local $INPUT_RECORD_SEPARATOR) = ();
 @foo = (local $RS) = ();
 @foo = (local $|) = ();
-@foo = (local $OUTPUT_AUTO_FLUSH) = ();
+@foo = (local $OUTPUT_AUTOFLUSH) = ();
 @foo = (local $,) = ();
 @foo = (local $OUTPUT_FIELD_SEPARATOR) = ();
 @foo = (local $OFS) = ();
@@ -701,7 +693,7 @@ local $SIG{foo} = 'bar';
 ===
 --- dscr: Named magic variables, pass non-local but in exception list
 --- failures: 0
---- params: {require_localized_punctuation_vars =>  {allow => '@+ $LAST_MATCH_END @- @LAST_MATCH_START @ARGV @F @INC @_ @ARG %OVERLOAD %+ %LAST_MATCH_END %- %LAST_MATCH_START %! %OS_ERROR %ERRNO %^H %INC %ENV %SIG $a $b $_ $ARG $& $MATCH $` $PREMATCH $\' $POSTMATCH $+ $LAST_PAREN_MATCH $* $MULTILINE_MATCHING $. $INPUT_LINE_NUMBER $NR $/ $INPUT_RECORD_SEPARATOR $RS $| $OUTPUT_AUTO_FLUSH $, $OUTPUT_FIELD_SEPARATOR $OFS $\\ $OUTPUT_RECORD_SEPARATOR $ORS $" $LIST_SEPARATOR $; $SUBSCRIPT_SEPARATOR $SUBSEP $# $OFMT $% $FORMAT_PAGE_NUMBER $= $FORMAT_LINES_PER_PAGE $- $FORMAT_LINES_LEFT $~ $FORMAT_NAME $^ $FORMAT_TOP_NAME $: $FORMAT_LINE_BREAK_CHARACTERS $? $CHILD_ERROR $^CHILD_ERROR_NATIVE $! $ERRNO $OS_ERROR $@ $EVAL_ERROR $$ $PROCESS_ID $PID $< $REAL_USER_ID $UID $> $EFFECTIVE_USER_ID $EUID $( $REAL_GROUP_ID $GID $) $EFFECTIVE_GROUP_ID $EGID $0 $PROGRAM_NAME $[ $] $^A $ACCUMULATOR $^C $COMPILING $^CHILD_ERROR_NATIVE $^D $DEBUGGING $^E $EXTENDED_OS_ERROR $^ENCODING $^F $SYSTEM_FD_MAX $^GLOBAL_PHASE $^H $^I $INPLACE_EDIT $^L $FORMAT_FORMFEED $^LAST_FH $^M $^MATCH $^N $LAST_SUBMATCH_RESULT $^O $OSNAME $^OPEN $^P $PERLDB $^PREMATCH $^POSTMATCH $^R $LAST_REGEXP_CODE_RESULT $^RE_DEBUG_FLAGS $^RE_TRIE_MAXBUF $^S $EXCEPTIONS_BEING_CAUGHT $^T $BASETIME $^TAINT $^UNICODE $^UTF8CACHE $^UTF8LOCALE $^V $PERL_VERSION $^W $WARNING $^WARNING_BITS $^WIDE_SYSTEM_CALLS $^WIN32_SLOPPY_STAT $^X $EXECUTABLE_NAME $ARGV *ARGV *_ *ARGVOUT *DATA *STDIN *STDOUT *STDERR'}}
+--- params: {require_localized_punctuation_vars =>  {allow => '@+ $LAST_MATCH_END @- @LAST_MATCH_START @ARGV @F @INC @_ @ARG %OVERLOAD %+ %LAST_MATCH_END %- %LAST_MATCH_START %! %OS_ERROR %ERRNO %^H %INC %ENV %SIG $a $b $_ $ARG $& $MATCH $` $PREMATCH $\' $POSTMATCH $+ $LAST_PAREN_MATCH $. $INPUT_LINE_NUMBER $NR $/ $INPUT_RECORD_SEPARATOR $RS $| $OUTPUT_AUTOFLUSH $, $OUTPUT_FIELD_SEPARATOR $OFS $\\ $OUTPUT_RECORD_SEPARATOR $ORS $" $LIST_SEPARATOR $; $SUBSCRIPT_SEPARATOR $SUBSEP $# $OFMT $% $FORMAT_PAGE_NUMBER $= $FORMAT_LINES_PER_PAGE $- $FORMAT_LINES_LEFT $~ $FORMAT_NAME $^ $FORMAT_TOP_NAME $: $FORMAT_LINE_BREAK_CHARACTERS $? $CHILD_ERROR $^CHILD_ERROR_NATIVE $! $ERRNO $OS_ERROR $@ $EVAL_ERROR $$ $PROCESS_ID $PID $< $REAL_USER_ID $UID $> $EFFECTIVE_USER_ID $EUID $( $REAL_GROUP_ID $GID $) $EFFECTIVE_GROUP_ID $EGID $0 $PROGRAM_NAME $[ $] $^A $ACCUMULATOR $^C $COMPILING $^CHILD_ERROR_NATIVE $^D $DEBUGGING $^E $EXTENDED_OS_ERROR $^ENCODING $^F $SYSTEM_FD_MAX $^GLOBAL_PHASE $^H $^I $INPLACE_EDIT $^L $FORMAT_FORMFEED $^LAST_FH $^M $^MATCH $^N $LAST_SUBMATCH_RESULT $^O $OSNAME $^OPEN $^P $PERLDB $^PREMATCH $^POSTMATCH $^R $LAST_REGEXP_CODE_RESULT $^RE_DEBUG_FLAGS $^RE_TRIE_MAXBUF $^S $EXCEPTIONS_BEING_CAUGHT $^T $BASETIME $^TAINT $^UNICODE $^UTF8CACHE $^UTF8LOCALE $^V $PERL_VERSION $^W $WARNING $^WARNING_BITS $^WIDE_SYSTEM_CALLS $^WIN32_SLOPPY_STAT $^X $EXECUTABLE_NAME $ARGV *ARGV *_ *ARGVOUT *DATA *STDIN *STDOUT *STDERR'}}
 --- input
 @+ = ();
 $LAST_MATCH_END = ();
@@ -733,8 +725,6 @@ $' = ();
 $POSTMATCH = ();
 $+ = ();
 $LAST_PAREN_MATCH = ();
-$* = ();
-$MULTILINE_MATCHING = ();
 $. = ();
 $INPUT_LINE_NUMBER = ();
 $NR = ();
@@ -742,7 +732,7 @@ $/ = ();
 $INPUT_RECORD_SEPARATOR = ();
 $RS = ();
 $| = ();
-$OUTPUT_AUTO_FLUSH = ();
+$OUTPUT_AUTOFLUSH = ();
 $, = ();
 $OUTPUT_FIELD_SEPARATOR = ();
 $OFS = ();
@@ -857,7 +847,7 @@ $ARGV = ();
 
 ===
 --- dscr: Named magic variables, fail non-local, non-carats
---- failures: 114
+--- failures: 112
 --- params:
 --- input
 @+ = ();
@@ -889,8 +879,6 @@ $' = ();
 $POSTMATCH = ();
 $+ = ();
 $LAST_PAREN_MATCH = ();
-$* = ();
-$MULTILINE_MATCHING = ();
 $. = ();
 $INPUT_LINE_NUMBER = ();
 $NR = ();
@@ -898,7 +886,7 @@ $/ = ();
 $INPUT_RECORD_SEPARATOR = ();
 $RS = ();
 $| = ();
-$OUTPUT_AUTO_FLUSH = ();
+$OUTPUT_AUTOFLUSH = ();
 $, = ();
 $OUTPUT_FIELD_SEPARATOR = ();
 $OFS = ();
@@ -1063,7 +1051,7 @@ $^X= ();
 
 ===
 --- dscr: Named magic variables, fail = (non-local) =
---- failures: 151
+--- failures: 149
 --- params:
 --- input
 @foo = (@+) = ();
@@ -1096,8 +1084,6 @@ $^X= ();
 @foo = ($POSTMATCH) = ();
 @foo = ($+) = ();
 @foo = ($LAST_PAREN_MATCH) = ();
-@foo = ($*) = ();
-@foo = ($MULTILINE_MATCHING) = ();
 @foo = ($.) = ();
 @foo = ($INPUT_LINE_NUMBER) = ();
 @foo = ($NR) = ();
@@ -1105,7 +1091,7 @@ $^X= ();
 @foo = ($INPUT_RECORD_SEPARATOR) = ();
 @foo = ($RS) = ();
 @foo = ($|) = ();
-@foo = ($OUTPUT_AUTO_FLUSH) = ();
+@foo = ($OUTPUT_AUTOFLUSH) = ();
 @foo = ($,) = ();
 @foo = ($OUTPUT_FIELD_SEPARATOR) = ();
 @foo = ($OFS) = ();
@@ -1220,7 +1206,7 @@ $^X= ();
 
 ===
 --- dscr: Named magic variables, fail (non-local)
---- failures: 151
+--- failures: 149
 --- params:
 --- input
 (@+) = ();
@@ -1253,8 +1239,6 @@ $^X= ();
 ($POSTMATCH) = ();
 ($+) = ();
 ($LAST_PAREN_MATCH) = ();
-($*) = ();
-($MULTILINE_MATCHING) = ();
 ($.) = ();
 ($INPUT_LINE_NUMBER) = ();
 ($NR) = ();
@@ -1262,7 +1246,7 @@ $^X= ();
 ($INPUT_RECORD_SEPARATOR) = ();
 ($RS) = ();
 ($|) = ();
-($OUTPUT_AUTO_FLUSH) = ();
+($OUTPUT_AUTOFLUSH) = ();
 ($,) = ();
 ($OUTPUT_FIELD_SEPARATOR) = ();
 ($OFS) = ();


### PR DESCRIPTION
As of version 1.15, B::Keywords renames $OUTPUT_AUTO_FLUSH to
$OUTPUT_AUTOFLUSH and removes $* and $MULTILINE_MATCHING for versions of
Perl older than 5.8.1.