### PR TITLE
fix warning

### DIFF
--- a/lib/Perl/Lint/Policy/Objects/IndirectSyntax.pm
+++ b/lib/Perl/Lint/Policy/Objects/IndirectSyntax.pm
@@ -35,7 +35,7 @@ sub evaluate {
                     filename => $file,
                     line     => $token->{line},
                     description => sprintf(DESC, $token_data),
-                    explanation => sprintf(EXPL, $token_data),
+                    explanation => EXPL,
                     policy => __PACKAGE__,
                 };
             }
@@ -46,4 +46,3 @@ sub evaluate {
 }
 
 1;
-


### PR DESCRIPTION
The warning in #99 look like a simple typo (```EXPL``` is an array and should be returned directly not fed through ```sprintf```).
