### PR TITLE
Restore B::Keywords test fixes

### DIFF
--- a/t/Policy/Variables/require_localized_punctuation_vars.t
+++ b/t/Policy/Variables/require_localized_punctuation_vars.t
@@ -857,7 +857,7 @@ $ARGV = ();
 
 ===
 --- dscr: Named magic variables, fail non-local, non-carats
---- failures: 114
+--- failures: 112
 --- params:
 --- input
 @+ = ();
@@ -889,8 +889,6 @@ $' = ();
 $POSTMATCH = ();
 $+ = ();
 $LAST_PAREN_MATCH = ();
-$* = ();
-$MULTILINE_MATCHING = ();
 $. = ();
 $INPUT_LINE_NUMBER = ();
 $NR = ();
@@ -898,7 +896,7 @@ $/ = ();
 $INPUT_RECORD_SEPARATOR = ();
 $RS = ();
 $| = ();
-$OUTPUT_AUTO_FLUSH = ();
+$OUTPUT_AUTOFLUSH = ();
 $, = ();
 $OUTPUT_FIELD_SEPARATOR = ();
 $OFS = ();
@@ -1063,7 +1061,7 @@ $^X= ();
 
 ===
 --- dscr: Named magic variables, fail = (non-local) =
---- failures: 151
+--- failures: 149
 --- params:
 --- input
 @foo = (@+) = ();
@@ -1096,8 +1094,6 @@ $^X= ();
 @foo = ($POSTMATCH) = ();
 @foo = ($+) = ();
 @foo = ($LAST_PAREN_MATCH) = ();
-@foo = ($*) = ();
-@foo = ($MULTILINE_MATCHING) = ();
 @foo = ($.) = ();
 @foo = ($INPUT_LINE_NUMBER) = ();
 @foo = ($NR) = ();
@@ -1105,7 +1101,7 @@ $^X= ();
 @foo = ($INPUT_RECORD_SEPARATOR) = ();
 @foo = ($RS) = ();
 @foo = ($|) = ();
-@foo = ($OUTPUT_AUTO_FLUSH) = ();
+@foo = ($OUTPUT_AUTOFLUSH) = ();
 @foo = ($,) = ();
 @foo = ($OUTPUT_FIELD_SEPARATOR) = ();
 @foo = ($OFS) = ();
@@ -1220,7 +1216,7 @@ $^X= ();
 
 ===
 --- dscr: Named magic variables, fail (non-local)
---- failures: 151
+--- failures: 149
 --- params:
 --- input
 (@+) = ();
@@ -1253,8 +1249,6 @@ $^X= ();
 ($POSTMATCH) = ();
 ($+) = ();
 ($LAST_PAREN_MATCH) = ();
-($*) = ();
-($MULTILINE_MATCHING) = ();
 ($.) = ();
 ($INPUT_LINE_NUMBER) = ();
 ($NR) = ();
@@ -1262,7 +1256,7 @@ $^X= ();
 ($INPUT_RECORD_SEPARATOR) = ();
 ($RS) = ();
 ($|) = ();
-($OUTPUT_AUTO_FLUSH) = ();
+($OUTPUT_AUTOFLUSH) = ();
 ($,) = ();
 ($OUTPUT_FIELD_SEPARATOR) = ();
 ($OFS) = ();


### PR DESCRIPTION
I fixed this in 32a6117fcf but that change was accidentally removed as
part of the release process in c3f71510a1.
